### PR TITLE
Lab2

### DIFF
--- a/src/Consumer.java
+++ b/src/Consumer.java
@@ -1,6 +1,9 @@
+import java.util.Random;
+
 public class Consumer extends Thread {
     private final int id;
     private final Monitor monitor;
+    private final Random random = new Random();
 
     public Consumer(int id, Monitor monitor) {
         this.id = id;
@@ -9,8 +12,8 @@ public class Consumer extends Thread {
 
     public void run() {
         while (true) {
-            System.out.println("Thread id: " + id + " buff = " + monitor.getBuff());
-            monitor.consume();
+            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
+            monitor.consume(randPortion, id);
         }
     }
 }

--- a/src/Consumer.java
+++ b/src/Consumer.java
@@ -1,14 +1,16 @@
 public class Consumer extends Thread {
+    private final int id;
     private final Monitor monitor;
 
-    public Consumer(Monitor monitor) {
+    public Consumer(int id, Monitor monitor) {
+        this.id = id;
         this.monitor = monitor;
     }
 
     public void run() {
         while (true) {
+            System.out.println("Thread id: " + id + " buff = " + monitor.getBuff());
             monitor.consume();
-            System.out.println("Consumed!");
         }
     }
 }

--- a/src/Consumer.java
+++ b/src/Consumer.java
@@ -1,0 +1,14 @@
+public class Consumer extends Thread {
+    private final Monitor monitor;
+
+    public Consumer(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    public void run() {
+        while (true) {
+            monitor.consume();
+            System.out.println("Consumed!");
+        }
+    }
+}

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,17 +1,13 @@
-// Press Shift twice to open the Search Everywhere dialog and type `show whitespaces`,
-// then press Enter. You can now see whitespace characters in your code.
 public class Main {
-    public static void main(String[] args) {
-        // Press Alt+Enter with your caret at the highlighted text to see how
-        // IntelliJ IDEA suggests fixing it.
-        System.out.printf("Hello and welcome!");
+    public static void main(String[] args) throws InterruptedException {
+        Monitor monitor = new Monitor();
+        Producer producer = new Producer(monitor);
+        Consumer consumer = new Consumer(monitor);
 
-        // Press Shift+F10 or click the green arrow button in the gutter to run the code.
-        for (int i = 1; i <= 5; i++) {
+        producer.start();
+        consumer.start();
 
-            // Press Shift+F9 to start debugging your code. We have set one breakpoint
-            // for you, but you can always add more by pressing Ctrl+F8.
-            System.out.println("i = " + i);
-        }
+        producer.join();
+        consumer.join();
     }
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -2,11 +2,13 @@ import java.util.LinkedList;
 
 public class Main {
     public static void main(String[] args) throws InterruptedException {
-        Monitor monitor = new Monitor();
-        LinkedList<Thread> threads = new LinkedList<>();
-
         int m = 2;
         int n = 1;
+        int w = 8;
+        int max_portion = 5; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
+
+        Monitor monitor = new Monitor(w, max_portion);
+        LinkedList<Thread> threads = new LinkedList<>();
 
         for (int i = 0; i < m; i++) {
             threads.add(new Producer(i + 1, monitor));

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,13 +1,30 @@
+import java.util.LinkedList;
+
 public class Main {
     public static void main(String[] args) throws InterruptedException {
         Monitor monitor = new Monitor();
-        Producer producer = new Producer(monitor);
-        Consumer consumer = new Consumer(monitor);
+        LinkedList<Thread> threads = new LinkedList<>();
 
-        producer.start();
-        consumer.start();
+        int m = 2;
+        int n = 1;
 
-        producer.join();
-        consumer.join();
+        for (int i = 0; i < m; i++) {
+            threads.add(new Producer(i + 1, monitor));
+        }
+
+        for (int i = 0; i < n; i++) {
+            threads.add(new Consumer(m + i + 1, monitor));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+
+
+
     }
 }

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -11,6 +11,7 @@ public class Monitor {
         }
 
         buff = 1;
+        System.out.println("Produced!");
         notify();
     }
 
@@ -24,6 +25,11 @@ public class Monitor {
         }
 
         buff = 0;
+        System.out.println("Consumed!");
         notify();
+    }
+
+    public int getBuff() {
+        return buff;
     }
 }

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -12,7 +12,7 @@ public class Monitor {
 
         buff = 1;
         System.out.println("Produced!");
-        notify();
+        notifyAll();
     }
 
     public synchronized void consume() {
@@ -26,7 +26,7 @@ public class Monitor {
 
         buff = 0;
         System.out.println("Consumed!");
-        notify();
+        notifyAll();
     }
 
     public int getBuff() {

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -1,8 +1,16 @@
 public class Monitor {
     private int buff = 0;
+    private final int maxPortion;
+    private final int buffLimit;
 
-    public synchronized void produce() {
-        while (buff == 1) {
+    public Monitor(int buffLimit, int maxPortion) {
+        this.buffLimit = buffLimit;
+        this.maxPortion = maxPortion;
+    }
+
+    public synchronized void produce(int portion, int threadId) {
+        while (buff + portion > buffLimit) {
+            System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
                 wait();
             } catch (InterruptedException e) {
@@ -10,13 +18,14 @@ public class Monitor {
             }
         }
 
-        buff = 1;
-        System.out.println("Produced!");
+        System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | produce");
+        buff += portion;
         notifyAll();
     }
 
-    public synchronized void consume() {
-        while (buff == 0) {
+    public synchronized void consume(int portion, int threadId) {
+        while (buff - portion < 0) {
+            System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
                 wait();
             } catch (InterruptedException e) {
@@ -24,12 +33,12 @@ public class Monitor {
             }
         }
 
-        buff = 0;
-        System.out.println("Consumed!");
+        System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | consume");
+        buff -= portion;
         notifyAll();
     }
 
-    public int getBuff() {
-        return buff;
+    public int getMaxPortion() {
+        return maxPortion;
     }
 }

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -1,0 +1,29 @@
+public class Monitor {
+    private int buff = 0;
+
+    public synchronized void produce() {
+        while (buff == 1) {
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        buff = 1;
+        notify();
+    }
+
+    public synchronized void consume() {
+        while (buff == 0) {
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        buff = 0;
+        notify();
+    }
+}

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -1,0 +1,14 @@
+public class Producer extends Thread {
+    private final Monitor monitor;
+
+    public Producer(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    public void run() {
+        while (true) {
+            monitor.produce();
+            System.out.println("Produced!");
+        }
+    }
+}

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -1,6 +1,9 @@
+import java.util.Random;
+
 public class Producer extends Thread {
     private final int id;
     private final Monitor monitor;
+    private final Random random = new Random();
 
     public Producer(int id, Monitor monitor) {
         this.id = id;
@@ -9,8 +12,8 @@ public class Producer extends Thread {
 
     public void run() {
         while (true) {
-            System.out.println("Thread id: " + id + " buff = " + monitor.getBuff());
-            monitor.produce();
+            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
+            monitor.produce(randPortion, id);
         }
     }
 }

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -1,14 +1,16 @@
 public class Producer extends Thread {
+    private final int id;
     private final Monitor monitor;
 
-    public Producer(Monitor monitor) {
+    public Producer(int id, Monitor monitor) {
+        this.id = id;
         this.monitor = monitor;
     }
 
     public void run() {
         while (true) {
+            System.out.println("Thread id: " + id + " buff = " + monitor.getBuff());
             monitor.produce();
-            System.out.println("Produced!");
         }
     }
 }


### PR DESCRIPTION
Problem Producent-Konsument w trzech wersjach:
1) 1P1K1B
2) MPNK1B
3) MPNKWB

ad1.
Proste rozwiązanie z `wait()`, `notify()`

ad2.
Poprawione na `notifyAll()`. Dla zwykłego `notify()` występuje zakleszczenie.
Dla przykładu:
```
Thread id: 1 buff = 1
Produced!
Thread id: 2 buff = 1
Thread id: 3 buff = 0
Consumed!
Thread id: 3 buff = 0
Produced!
Thread id: 1 buff = 1
```

ad3.
Dodany buffor wieloelementowy. Jeśli maksymalna wylosowana porcja do skonsumowania/wyprodukowania będzie większa niż połowa wielkości buffora, wystąpi zakleszczenie.
Dla przykładu:
```
Thread id: 3 (consumer) buff = 2 portion = 4 | wait()
Thread id: 2 (producer) buff = 2 portion = 3 | produce
Thread id: 2 (producer) buff = 5 portion = 3 | produce
Thread id: 2 (producer) buff = 8 portion = 5 | wait()
Thread id: 3 (consumer) buff = 8 portion = 4 | consume
Thread id: 3 (consumer) buff = 4 portion = 5 | wait()
Thread id: 2 (producer) buff = 4 portion = 5 | wait()
Thread id: 1 (producer) buff = 4 portion = 5 | wait()
```
