### PR TITLE
Lab3

### DIFF
--- a/src/Consumer.java
+++ b/src/Consumer.java
@@ -12,7 +12,8 @@ public class Consumer extends Thread {
 
     public void run() {
         while (true) {
-            monitor.consume(1, id);
+            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
+            monitor.consume(randPortion, id);
         }
     }
 }

--- a/src/Consumer.java
+++ b/src/Consumer.java
@@ -12,8 +12,7 @@ public class Consumer extends Thread {
 
     public void run() {
         while (true) {
-            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
-            monitor.consume(randPortion, id);
+            monitor.consume(1, id);
         }
     }
 }

--- a/src/EvilProducer.java
+++ b/src/EvilProducer.java
@@ -1,0 +1,17 @@
+import java.util.Random;
+
+public class EvilProducer extends Thread {
+    private final int id;
+    private final Monitor monitor;
+
+    public EvilProducer(int id, Monitor monitor) {
+        this.id = id;
+        this.monitor = monitor;
+    }
+
+    public void run() {
+        while (true) {
+            monitor.produce(monitor.getBuffLimit()-1, id);
+        }
+    }
+}

--- a/src/EvilProducer.java
+++ b/src/EvilProducer.java
@@ -11,7 +11,7 @@ public class EvilProducer extends Thread {
 
     public void run() {
         while (true) {
-            monitor.produce(monitor.getBuffLimit()-1, id);
+            monitor.produce(50, id);
         }
     }
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -2,10 +2,10 @@ import java.util.LinkedList;
 
 public class Main {
     public static void main(String[] args) throws InterruptedException {
-        int m = 2;
-        int n = 1;
+        int m = 5;
+        int n = 4;
         int w = 8;
-        int max_portion = 5; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
+        int max_portion = 4; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
 
         Monitor monitor = new Monitor(w, max_portion);
         LinkedList<Thread> threads = new LinkedList<>();

--- a/src/Main.java
+++ b/src/Main.java
@@ -5,7 +5,7 @@ public class Main {
         int m = 400;
         int n = 400;
         int w = 100;
-        int max_portion = 10; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
+        int max_portion = 5; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
 
         Monitor monitor = new Monitor(w, max_portion);
         LinkedList<Thread> threads = new LinkedList<>();

--- a/src/Main.java
+++ b/src/Main.java
@@ -2,8 +2,8 @@ import java.util.LinkedList;
 
 public class Main {
     public static void main(String[] args) throws InterruptedException {
-        int m = 400;
-        int n = 400;
+        int m = 2;
+        int n = 2;
         int w = 100;
         int max_portion = 5; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -2,10 +2,10 @@ import java.util.LinkedList;
 
 public class Main {
     public static void main(String[] args) throws InterruptedException {
-        int m = 5;
-        int n = 4;
-        int w = 8;
-        int max_portion = 4; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
+        int m = 400;
+        int n = 400;
+        int w = 100;
+        int max_portion = 10; // jeśli max_portion będzie większy niż połowa buffora, wystąpi zakleszczenie
 
         Monitor monitor = new Monitor(w, max_portion);
         LinkedList<Thread> threads = new LinkedList<>();
@@ -17,6 +17,8 @@ public class Main {
         for (int i = 0; i < n; i++) {
             threads.add(new Consumer(m + i + 1, monitor));
         }
+
+        threads.add(new EvilProducer(1000, monitor));
 
         for (Thread thread : threads) {
             thread.start();

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -2,7 +2,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Monitor {
-    private int buff = 0;
+    private int buff = 50;
     private final int maxPortion;
     private final int buffLimit;
     private final ReentrantLock lock = new ReentrantLock();
@@ -17,7 +17,7 @@ public class Monitor {
     public void produce(int portion, int threadId) {
         lock.lock();
         while (buff + portion > buffLimit) {
-            System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | wait()");
+            if(threadId == 1000) System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
                 bufferFullCondition.await();
             } catch (InterruptedException e) {
@@ -25,7 +25,7 @@ public class Monitor {
             }
         }
 
-        System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | produce");
+        if(threadId == 1000) System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | produce");
         buff += portion;
         bufferReadyCondition.signal();
         lock.unlock();
@@ -34,7 +34,6 @@ public class Monitor {
     public void consume(int portion, int threadId) {
         lock.lock();
         while (buff - portion < 0) {
-            System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
                 bufferReadyCondition.await();
             } catch (InterruptedException e) {
@@ -42,7 +41,6 @@ public class Monitor {
             }
         }
 
-        System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | consume");
         buff -= portion;
         bufferFullCondition.signal();
         lock.unlock();
@@ -50,5 +48,9 @@ public class Monitor {
 
     public int getMaxPortion() {
         return maxPortion;
+    }
+
+    public int getBuffLimit() {
+        return buffLimit;
     }
 }

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -1,18 +1,25 @@
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
 public class Monitor {
     private int buff = 0;
     private final int maxPortion;
     private final int buffLimit;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition bufferReadyCondition = lock.newCondition();
+    private final Condition bufferFullCondition = lock.newCondition();
 
     public Monitor(int buffLimit, int maxPortion) {
         this.buffLimit = buffLimit;
         this.maxPortion = maxPortion;
     }
 
-    public synchronized void produce(int portion, int threadId) {
+    public void produce(int portion, int threadId) {
+        lock.lock();
         while (buff + portion > buffLimit) {
             System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
-                wait();
+                bufferFullCondition.await();
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -20,14 +27,15 @@ public class Monitor {
 
         System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | produce");
         buff += portion;
-        notifyAll();
+        bufferReadyCondition.signal();
     }
 
-    public synchronized void consume(int portion, int threadId) {
+    public void consume(int portion, int threadId) {
+        lock.lock();
         while (buff - portion < 0) {
             System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | wait()");
             try {
-                wait();
+                bufferReadyCondition.await();
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -35,7 +43,7 @@ public class Monitor {
 
         System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | consume");
         buff -= portion;
-        notifyAll();
+        bufferFullCondition.signal();
     }
 
     public int getMaxPortion() {

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -81,3 +81,5 @@ public class Monitor {
         return buffLimit;
     }
 }
+
+// haswatiers nie interesuje nas czy ktoś jest na await (obserwujemy coś innego) w tym czasie inne wątki mogą wchodzić

--- a/src/Monitor.java
+++ b/src/Monitor.java
@@ -28,6 +28,7 @@ public class Monitor {
         System.out.println("Thread id: " + threadId + " (producer) buff = " + buff + " portion = " + portion + " | produce");
         buff += portion;
         bufferReadyCondition.signal();
+        lock.unlock();
     }
 
     public void consume(int portion, int threadId) {
@@ -44,6 +45,7 @@ public class Monitor {
         System.out.println("Thread id: " + threadId + " (consumer) buff = " + buff + " portion = " + portion + " | consume");
         buff -= portion;
         bufferFullCondition.signal();
+        lock.unlock();
     }
 
     public int getMaxPortion() {

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -12,8 +12,7 @@ public class Producer extends Thread {
 
     public void run() {
         while (true) {
-            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
-            monitor.produce(randPortion, id);
+            monitor.produce(1, id);
         }
     }
 }

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -12,7 +12,8 @@ public class Producer extends Thread {
 
     public void run() {
         while (true) {
-            monitor.produce(1, id);
+            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
+            monitor.produce(randPortion, id);
         }
     }
 }

--- a/src/Producer.java
+++ b/src/Producer.java
@@ -12,7 +12,7 @@ public class Producer extends Thread {
 
     public void run() {
         while (true) {
-            int randPortion = random.nextInt(monitor.getMaxPortion()) + 1;
+            int randPortion = random.nextInt(monitor.getMaxPortion());
             monitor.produce(randPortion, id);
         }
     }


### PR DESCRIPTION
# Problem zagłodzenia

### Zagłodzenie na 2 condition:

```java
int m = 400;
int n = 400;
int w = 100;
int max_portion = 5;
```
Jeden wątek zawsze produkuje 50.

```
...
Thread id: 1000 (producer) buff = 99 portion = 50 | wait()
Thread id: 1000 (producer) buff = 99 portion = 50 | wait()
Thread id: 1000 (producer) buff = 98 portion = 50 | wait()
Thread id: 1000 (producer) buff = 97 portion = 50 | wait()
Thread id: 1000 (producer) buff = 100 portion = 50 | wait()
Thread id: 1000 (producer) buff = 97 portion = 50 | wait()
Thread id: 1000 (producer) buff = 98 portion = 50 | wait()
Thread id: 1000 (producer) buff = 97 portion = 50 | wait()
Thread id: 1000 (producer) buff = 99 portion = 50 | wait()
```

### Rowziązanie na 4 condition (brak zagłodzenia):
```
...
Thread id: 1000 (producer) buff = 100 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 4 portion = 50 | produce
Thread id: 1000 (producer) buff = 54 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 36 portion = 50 | produce
Thread id: 1000 (producer) buff = 100 portion = 50 | wait()
Thread id: 1000 (producer) buff = 53 portion = 50 | wait()
```

### Niepoprawne rozwiązanie na 4 condition z `hasWaiters()`

Zagłodzenie:
```
...
Thread id: 1000 (producer) buff = 99 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 99 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 98 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 100 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 100 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 100 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 100 portion = 50 | firstProducer wait()
Thread id: 1000 (producer) buff = 99 portion = 50 | firstProducer wait()
```

Występuje ponieważ kiedy wątek wyjdzie z firstCondition (wtedy hasWaiters zwraca false) i jakiś inny wątek mu go zajmie (chyba tak to działa)


Nie mam pojęcia jak pokazać zakleszczenie z `hasWaiters()`

